### PR TITLE
Missing lifelines package when importing 3.0.1 version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -134,6 +134,7 @@ dependencies:
     - kiwisolver==1.4.4
     - lazy-loader==0.3
     - libclang==14.0.6
+    - lifelines==0.29.0
     - llvmlite==0.39.1
     - locket==1.0.0
     - markdown==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ zarr
 fastai
 gdown
 triangle
+lifelines


### PR DESCRIPTION
**Summary**

Installation of 3.0.1 version runs without error. However, lifelines package is missing when running:

`import slideflow`

**Implementation**

Include lifelines in the requirements.txt file and the environment.yml file