### PR TITLE
Fixes to the tests

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -18,7 +18,7 @@ from slideflow.util import colors as col
 @click.option('--all', 'all_tests', help='Perform all tests.',
               required=False, type=bool)
 @click.option('--unit', help='Run unit tests.',
-              required=False, type=bool, default=True)
+              required=False, type=bool, default=False)
 @click.option('--extract', help='Test tile extraction.',
               required=False, type=bool)
 @click.option('--reader', help='Test TFRecord readers.',

--- a/slideflow/test/__init__.py
+++ b/slideflow/test/__init__.py
@@ -105,7 +105,7 @@ class TestSuite:
         self.buffer = buffer
 
         # Rebuild tfrecord indices
-        self.project.dataset(self.tile_px, 1208).build_index(True)
+        self.project.dataset(self.tile_px, 604).build_index(True)
 
         # Set up training keyword arguments.
         self.train_kwargs = dict(
@@ -172,7 +172,7 @@ class TestSuite:
         if sweep:
             self.project.create_hp_sweep(
                 tile_px=self.tile_px,
-                tile_um=1208,
+                tile_um=604,
                 epochs=[1, 3],
                 toplayer_epochs=[0],
                 model=["mobilenet_v2"],
@@ -199,7 +199,7 @@ class TestSuite:
         # Create single hyperparameter combination
         hp = sf.ModelParams(
             tile_px=self.tile_px,
-            tile_um=1208,
+            tile_um=604,
             epochs=1,
             toplayer_epochs=0,
             model="mobilenet_v2",
@@ -232,7 +232,7 @@ class TestSuite:
             try:
                 self.project.extract_tiles(
                     tile_px=self.tile_px,
-                    tile_um=1208,
+                    tile_um=604,
                     buffer=self.buffer,
                     source=['TEST'],
                     roi_method='ignore',
@@ -243,7 +243,7 @@ class TestSuite:
                 )
                 self.project.extract_tiles(
                     tile_px=self.tile_px,
-                    tile_um="2.5x",
+                    tile_um="10x",
                     buffer=self.buffer,
                     source=['TEST'],
                     roi_method='ignore',
@@ -469,7 +469,7 @@ class TestSuite:
             with TaskWrapper("Training with single regression outcome...") as test:
                 try:
                     results = self.project.train(
-                        outcomes=['regression1'],
+                        outcomes=['continuous1'],
                         val_k=1,
                         params=self.setup_hp('regression'),
                         pretrain=None,
@@ -485,7 +485,7 @@ class TestSuite:
             with TaskWrapper("Training multiple regression outcomes...") as test:
                 try:
                     results = self.project.train(
-                        outcomes=['regression1', 'regression2'],
+                        outcomes=['continuous1', 'continuous2'],
                         val_k=1,
                         params=self.setup_hp('regression'),
                         pretrain=None,
@@ -594,7 +594,7 @@ class TestSuite:
 
         assert self.project is not None
         multi_cat_model = self._get_model('category1-category2-HP0-kfold1')
-        multi_lin_model = self._get_model('regression1-regression2-HP0-kfold1')
+        multi_lin_model = self._get_model('continuous1-continuous2-HP0-kfold1')
         multi_inp_model = self._get_model('category1-multi_input-HP0-kfold1')
         f_model = self._get_model('category1-manual_hp-TEST-HPSweep0-kfold1')
 
@@ -642,7 +642,7 @@ class TestSuite:
                 sf.test.functional.evaluation_tester,
                 project=self.project,
                 model=multi_lin_model,
-                outcomes=['regression1', 'regression2'],
+                outcomes=['continuous1', 'continuous2'],
                 save_predictions=True,
                 **eval_kwargs
             )
@@ -764,7 +764,7 @@ class TestSuite:
                 test.skip()
             else:
                 try:
-                    dataset = self.project.dataset(self.tile_px, 1208)
+                    dataset = self.project.dataset(self.tile_px, 604)
                     train_dts, val_dts = dataset.split(val_fraction=0.3)
                     import slideflow.mil
                     config = sf.mil.mil_config('attention_mil', epochs=5, lr=1e-4, drop_last=False)
@@ -838,7 +838,7 @@ class TestSuite:
             pass
 
         print("Running unit tests...")
-        runner = unittest.TextTestRunner()
+        runner = unittest.TextTestRunner(verbosity=2)
         all_tests = [
             unittest.TestLoader().loadTestsFromModule(module)
             for module in (norm_test, dataset_test, stats_test, model_test)

--- a/slideflow/test/functional.py
+++ b/slideflow/test/functional.py
@@ -34,7 +34,7 @@ def activations_tester(
     sf.setLoggingLevel(verbosity)
 
     # Test activations generation.
-    dataset = project.dataset(tile_px, 1208)
+    dataset = project.dataset(tile_px, 604)
     test_slide = dataset.slides()[0]
 
     df = project.generate_features(
@@ -133,7 +133,7 @@ def reader_tester(project, verbosity, passed, tile_px) -> None:
 
     Function must happen in an isolated process to free GPU memory when done.
     """
-    dataset = project.dataset(tile_px, 1208)
+    dataset = project.dataset(tile_px, 604)
     tfrecords = dataset.tfrecords()
     batch_size = 128
     assert len(tfrecords)
@@ -208,7 +208,7 @@ def single_thread_normalizer_tester(
     sf.setLoggingLevel(verbosity)
     if not len(methods):
         methods = sf.norm.StainNormalizer.normalizers  # type: ignore
-    dataset = project.dataset(tile_px, 1208)
+    dataset = project.dataset(tile_px, 604)
     v = f'[bold]({sf.backend()}-native)[/]'
 
     dts_kw = {'standardize': False, 'infinite': True}
@@ -259,7 +259,7 @@ def multi_thread_normalizer_tester(
     sf.setLoggingLevel(verbosity)
     if not len(methods):
         methods = sf.norm.StainNormalizer.normalizers  # type: ignore
-    dataset = project.dataset(tile_px, 1208)
+    dataset = project.dataset(tile_px, 604)
     v = f'[bold]({sf.backend()}-native)[/]'
 
     for method in methods:

--- a/slideflow/test/slide_test.py
+++ b/slideflow/test/slide_test.py
@@ -12,7 +12,7 @@ class TestSlide(unittest.TestCase):
         super().__init__(testname)
         self.wsi_path = path
         self.tile_px = tile_px
-        self.kw = dict(tile_px=tile_px, tile_um=1208)
+        self.kw = dict(tile_px=tile_px, tile_um=604)
         self.wsi = sf.WSI(self.wsi_path, roi_method='ignore', **self.kw)
 
     def _assert_is_image(self, img: np.ndarray):

--- a/slideflow/test/stats_test.py
+++ b/slideflow/test/stats_test.py
@@ -184,7 +184,7 @@ class TestMetrics(unittest.TestCase):
         self.assertIn('patient', dfs['patient'].columns)
         return dfs
 
-    def _assert_categorical_metrics(self, metrics, outcomes, lengths):
+    def _assert_classification_metrics(self, metrics, outcomes, lengths):
         for outcome, length in zip(outcomes, lengths):
             self.assertTrue(metrics is not None)
             self.assertIsInstance(metrics, dict)
@@ -212,18 +212,18 @@ class TestMetrics(unittest.TestCase):
         )
         dfs = self._group_reduce(tile_df)
         for level, _df in dfs.items():
-            metrics = sf.stats.metrics.categorical_metrics(_df, level=level)
-            self._assert_categorical_metrics(metrics, ['out0'], [self.n_labels1])
+            metrics = sf.stats.metrics.classification_metrics(_df, level=level)
+            self._assert_classification_metrics(metrics, ['out0'], [self.n_labels1])
 
     def test_single_categorical_named(self):
         tile_df = sf.stats.df_from_pred(
             *self._get_single_categorical_data()
         )
-        tile_df = sf.stats.name_columns(tile_df, 'categorical', 'Named1')
+        tile_df = sf.stats.name_columns(tile_df, 'classification', 'Named1')
         dfs = self._group_reduce(tile_df)
         for level, _df in dfs.items():
-            metrics = sf.stats.metrics.categorical_metrics(_df, level=level)
-            self._assert_categorical_metrics(metrics, ['Named1'], [self.n_labels1])
+            metrics = sf.stats.metrics.classification_metrics(_df, level=level)
+            self._assert_classification_metrics(metrics, ['Named1'], [self.n_labels1])
 
     def test_multi_categorical(self):
         tile_df = sf.stats.df_from_pred(
@@ -231,8 +231,8 @@ class TestMetrics(unittest.TestCase):
         )
         dfs = self._group_reduce(tile_df)
         for level, _df in dfs.items():
-            metrics = sf.stats.metrics.categorical_metrics(_df, level=level)
-            self._assert_categorical_metrics(
+            metrics = sf.stats.metrics.classification_metrics(_df, level=level)
+            self._assert_classification_metrics(
                 metrics,
                 ['out0', 'out1'],
                 [self.n_labels1, self.n_labels2]
@@ -244,13 +244,13 @@ class TestMetrics(unittest.TestCase):
         )
         tile_df = sf.stats.name_columns(
             tile_df,
-            'categorical',
+            'classification',
             ['Named1', 'Named2']
         )
         dfs = self._group_reduce(tile_df)
         for level, _df in dfs.items():
-            metrics = sf.stats.metrics.categorical_metrics(_df, level=level)
-            self._assert_categorical_metrics(
+            metrics = sf.stats.metrics.classification_metrics(_df, level=level)
+            self._assert_classification_metrics(
                 metrics,
                 ['Named1', 'Named2'],
                 [self.n_labels1, self.n_labels2]
@@ -260,7 +260,7 @@ class TestMetrics(unittest.TestCase):
         tile_df = sf.stats.df_from_pred(
             *self._get_single_continuous_data()
         )
-        tile_df = sf.stats.name_columns(tile_df, 'continuous', ['NamedContinuous1'])
+        tile_df = sf.stats.name_columns(tile_df, 'regression', ['NamedContinuous1'])
         dfs = self._group_reduce(tile_df)
         for level, _df in dfs.items():
             metrics = sf.stats.metrics.regression_metrics(_df, level=level)
@@ -272,7 +272,7 @@ class TestMetrics(unittest.TestCase):
         )
         tile_df = sf.stats.name_columns(
             tile_df,
-            'continuous',
+            'regression',
             ['NamedContinuous1', 'NamedContinuous2']
         )
         dfs = self._group_reduce(tile_df)

--- a/slideflow/test/utils.py
+++ b/slideflow/test/utils.py
@@ -84,7 +84,7 @@ def random_annotations(
     else:
         slides = [f'slide{i}' for i in range(10)]
     annotations = [['patient', 'slide', 'dataset', 'category1', 'category2',
-                    'regression1', 'regression2', 'time', 'event']]
+                    'continuous1', 'continuous2', 'time', 'event']]
     for s, slide in enumerate(slides):
         cat1 = ['A', 'B'][s % 2]
         cat2 = ['A', 'B'][s % 2]


### PR DESCRIPTION
 Corrected `sf.stats.metrics.categorical_metrics` to `classification_metrics`. 

Corrected some "regression"/"continuous"/"linear" arguments.

I changed some `tile_um=1208` to `604` (and '2.5x' to '10x') because my test dataset had very small slides and some had issues with such big tiles.

I wanted to fix these tests to properly test https://github.com/slideflow/slideflow/pull/408.