### PR TITLE
 Add ordinal classification support to MIL models

### DIFF
--- a/slideflow/mil/_params.py
+++ b/slideflow/mil/_params.py
@@ -55,7 +55,6 @@ class TrainerConfig:
         drop_last: bool = True,
         save_monitor: str = 'valid_loss',
         weighted_loss: bool = True,
-        ordinal: bool = False,
         **kwargs
     ):
         r"""Training configuration for FastAI MIL models.
@@ -102,9 +101,6 @@ class TrainerConfig:
         self.drop_last = drop_last
         self.save_monitor = save_monitor
         self.weighted_loss = weighted_loss
-        self.ordinal = ordinal
-        if ordinal:
-            kwargs['loss'] = 'BCEWithLogitsLoss'
         if isinstance(model, str):
             self.model_config = build_model_config(model, **kwargs)
         else:
@@ -607,7 +603,7 @@ class MILModelConfig:
         'mse': nn.MSELoss,
         'mae': nn.L1Loss,
         'huber': nn.SmoothL1Loss,
-        'BCEWithLogitsLoss': nn.BCEWithLogitsLoss,
+        'BCE_ordinal': nn.BCEWithLogitsLoss,
     }
 
     def __init__(
@@ -699,7 +695,7 @@ class MILModelConfig:
         # TODO:m ordinal classification same as classification?
         if self.loss == 'cross_entropy':
             return 'classification'
-        elif self.loss == 'BCEWithLogitsLoss':
+        elif self.loss == 'BCE_ordinal':
             return 'ordinal'
         else:
             return 'regression'

--- a/slideflow/mil/_params.py
+++ b/slideflow/mil/_params.py
@@ -154,10 +154,6 @@ class TrainerConfig:
     def _verify_eval_params(self, **kwargs):
         pass
 
-    def model_type(self):
-        """Model type."""
-        return self.model_config.model_type
-
     def is_classification(self):
         """Whether the model is a classification model."""
         return self.model_config.is_classification()

--- a/slideflow/mil/eval.py
+++ b/slideflow/mil/eval.py
@@ -159,7 +159,8 @@ def predict_mil(
         )
 
     # Prepare labels.
-    labels, _ = utils.get_labels(dataset, outcomes, config.is_classification(), format='id')
+    categorical = config.model_type() in ['classification', 'ordinal']
+    labels, _ = utils.get_labels(dataset, outcomes, categorical, format='id')
 
     # Prepare bags and targets.
     slides = list(labels.keys())
@@ -896,7 +897,8 @@ def get_mil_tile_predictions(
     model.to(device)
 
     if outcomes is not None:
-        labels, _ = utils.get_labels(dataset, outcomes, config.is_classification(), format='id')
+        categorical = config.model_type() in ['classification', 'ordinal']
+        labels, _ = utils.get_labels(dataset, outcomes, categorical, format='id')
 
     # Prepare bags.
     slides = dataset.slides()

--- a/slideflow/mil/eval.py
+++ b/slideflow/mil/eval.py
@@ -159,7 +159,7 @@ def predict_mil(
         )
 
     # Prepare labels.
-    categorical = config.model_type() in ['classification', 'ordinal']
+    categorical = config.model_type in ['classification', 'ordinal']
     labels, _ = utils.get_labels(dataset, outcomes, categorical, format='id')
 
     # Prepare bags and targets.
@@ -897,7 +897,7 @@ def get_mil_tile_predictions(
     model.to(device)
 
     if outcomes is not None:
-        categorical = config.model_type() in ['classification', 'ordinal']
+        categorical = config.model_type in ['classification', 'ordinal']
         labels, _ = utils.get_labels(dataset, outcomes, categorical, format='id')
 
     # Prepare bags.

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -126,7 +126,10 @@ def build_fastai_learner(
     """
     from . import _fastai
 
-    if config.model_type() in ['classification', 'ordinal']:
+    categorical = False
+    debug = config.model_type
+    print(f"DEBUG: {debug}")
+    if config.model_type in ['classification', 'ordinal']:
         categorical = True
 
     labels, unique = utils.get_labels((train_dataset, val_dataset), outcomes, categorical)
@@ -426,9 +429,9 @@ def _train_mil(
         df.to_parquet(pred_out)
         log.info(f"Predictions saved to [green]{pred_out}[/]")
 
-    categorical = True if config.model_type() in ['classification', 'ordinal'] else False
+    categorical = True if config.model_type in ['classification', 'ordinal'] else False
         
-    if config.model_type() == 'ordinal':
+    if config.model_type == 'ordinal':
         utils.create_preds(df)
 
     # Print classification metrics, including per-category accuracy

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -426,8 +426,13 @@ def _train_mil(
         df.to_parquet(pred_out)
         log.info(f"Predictions saved to [green]{pred_out}[/]")
 
+    categorical = True if config.model_type() in ['classification', 'ordinal'] else False
+        
+    if config.model_type() == 'ordinal':
+        utils.create_preds(df)
+
     # Print classification metrics, including per-category accuracy
-    utils.rename_df_cols(df, outcomes, categorical=config.is_classification(), inplace=True)
+    utils.rename_df_cols(df, outcomes, categorical=categorical, inplace=True) # TODO:m change to model type
     config.run_metrics(df, level='slide', outdir=outdir)
 
     # Export attention to numpy arrays

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -126,7 +126,10 @@ def build_fastai_learner(
     """
     from . import _fastai
 
-    labels, unique = utils.get_labels((train_dataset, val_dataset), outcomes, config.is_classification())
+    if config.model_type() in ['classification', 'ordinal']:
+        categorical = True
+
+    labels, unique = utils.get_labels((train_dataset, val_dataset), outcomes, categorical)
 
     # Prepare bags
     if isinstance(bags, str) or (isinstance(bags, list) and isdir(bags[0])):

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -127,8 +127,6 @@ def build_fastai_learner(
     from . import _fastai
 
     categorical = False
-    debug = config.model_type
-    print(f"DEBUG: {debug}")
     if config.model_type in ['classification', 'ordinal']:
         categorical = True
 

--- a/slideflow/mil/train/__init__.py
+++ b/slideflow/mil/train/__init__.py
@@ -432,7 +432,7 @@ def _train_mil(
         utils.create_preds(df)
 
     # Print classification metrics, including per-category accuracy
-    utils.rename_df_cols(df, outcomes, categorical=categorical, inplace=True) # TODO:m change to model type
+    utils.rename_df_cols(df, outcomes, categorical=categorical, inplace=True)
     config.run_metrics(df, level='slide', outdir=outdir)
 
     # Export attention to numpy arrays

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -173,7 +173,7 @@ def build_learner(
 
     if config.is_classification():
         encoder = OneHotEncoder(**oh_kw).fit(unique_categories.reshape(-1, 1))
-    elif config.model_type() == 'ordinal': # TODO:m create function
+    elif config.model_type() == 'ordinal':
         encoder = OrdinalClassEncoder().fit(unique_categories.reshape(-1, 1))
     else:
         encoder = None

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -173,7 +173,7 @@ def build_learner(
 
     if config.is_classification():
         encoder = OneHotEncoder(**oh_kw).fit(unique_categories.reshape(-1, 1))
-    elif config.model_type() == 'ordinal':
+    elif config.model_type == 'ordinal':
         encoder = OrdinalClassEncoder().fit(unique_categories.reshape(-1, 1))
     else:
         encoder = None

--- a/slideflow/mil/train/_fastai.py
+++ b/slideflow/mil/train/_fastai.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import numpy.typing as npt
 from typing import List, Optional, Union, Tuple
+from sklearn.preprocessing._encoders import _BaseEncoder
 from sklearn.preprocessing import OneHotEncoder
 from sklearn import __version__ as sklearn_version
 from packaging import version
@@ -47,6 +48,80 @@ def train(learner, config, callbacks=None):
             lr = config.lr
         learner.fit(n_epoch=config.epochs, lr=lr, wd=config.wd, cbs=cbs)
     return learner
+
+class OrdinalClassEncoder(_BaseEncoder):
+    """Encode categorical features as ordinal numbers.
+    
+    For k classes, creates k-1 bits where:
+    - First class is encoded as all zeros
+    - Last class is encoded as all ones
+    - Each class has one more '1' than the previous class
+    
+    Example for 4 classes:
+    Class 1: [0, 0, 0]
+    Class 2: [0, 0, 1]
+    Class 3: [0, 1, 1]
+    Class 4: [1, 1, 1]
+    """
+
+    def __init__(self):
+        self.categories_ = None
+        self.ordinal_map_ = None
+    
+    def fit(self, X):
+        """Fit the OrdinalClassEncoder to X.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to determine the categories of each feature.
+        
+        Returns
+        -------
+        self
+        """
+        X_list, n_samples, n_features = self._check_X(X)
+        
+        if n_features != 1:
+            raise ValueError("X should have exactly one feature")
+        
+        # Get unique categories and sort them
+        self.categories_ = [np.unique(X_list[0])]
+        
+        # Create ordinal mapping
+        num_bits = len(self.categories_[0]) - 1
+        self.ordinal_map_ = {}
+        
+        for i, category in enumerate(self.categories_[0]):
+            # Create encoding where last i bits are 1 and rest are 0
+            encoding = [1 if j >= (num_bits - i) else 0 for j in range(num_bits)]
+            self.ordinal_map_[category] = encoding
+            
+        return self
+    
+    def transform(self, X):
+        """Transform X using ordinal encoding.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to encode.
+            
+        Returns
+        -------
+        X_out : ndarray of shape (n_samples, n_features)
+            Transformed input.
+        """
+        X_list, n_samples, n_features = self._check_X(X)
+        
+        if n_features != 1:
+            raise ValueError("X should have exactly one feature")
+            
+        # Convert to numpy array of ordinal encodings
+        result = np.array([self.ordinal_map_[x] for x in X_list[0]])
+        
+        return result
+
 
 # -----------------------------------------------------------------------------
 
@@ -98,6 +173,8 @@ def build_learner(
 
     if config.is_classification():
         encoder = OneHotEncoder(**oh_kw).fit(unique_categories.reshape(-1, 1))
+    elif config.model_type() == 'ordinal': # TODO:m create function
+        encoder = OrdinalClassEncoder().fit(unique_categories.reshape(-1, 1))
     else:
         encoder = None
 


### PR DESCRIPTION
This PR adds support for ordinal classification in MIL models, where classes have an inherent order (e.g., grades 1-4). The key additions include:

## Changes

1. Added `OrdinalClassEncoder` class that encodes ordinal classes using a binary encoding scheme where:
   - For k classes, creates k-1 bits
   - First class is encoded as all zeros
   - Last class is encoded as all ones
   - Each class has one more '1' than the previous class
   
   Example for 4 classes:
   ```
   Class 1: [0, 0, 0]
   Class 2: [0, 0, 1] 
   Class 3: [0, 1, 1]
   Class 4: [1, 1, 1]
   ```

2. Added `create_preds()` utility function to convert binary ordinal predictions to class probabilities:
   - Takes n-1 binary predictions and converts to n class probabilities
   - Applies sigmoid to raw outputs
   - Uses a custom conversion scheme to ensure proper ordinal relationships
   - Applies softmax to get final probabilities

3. Updated model configuration and evaluation logic:
   - Added 'BCE_ordinal' loss type using `nn.BCEWithLogitsLoss`
   - Modified `model_type` property to handle ordinal classification
   - Updated metrics and evaluation code to treat ordinal same as classification
   - Added ordinal encoder support in FastAI learner builder

## Usage

To use ordinal classification:

1. Set the loss type to 'BCE_ordinal' in the model config
2. Classes will be automatically encoded using the ordinal encoding scheme
3. Model outputs n-1 binary predictions that are converted to n class probabilities

The same metrics (AUROC, etc.) used for regular classification are applied to ordinal models.

## Testing

I created a very simple fake dataset to test this

https://uchicago.box.com/s/0vbqv0d81998k699oevd0yhfqkvkbdpb